### PR TITLE
Add filter and find by account function to contributors

### DIFF
--- a/lib/contracts/contributor.js
+++ b/lib/contracts/contributor.js
@@ -49,9 +49,10 @@ class Contributor extends Base {
       return contributors[method]((contributor) => {
         if (!contributor.accounts) { return false; }
         return contributor.accounts.find((account) => {
-          return searchEntries.reduce((accumulator, searchValue) => {
-            return accumulator && account[searchValue[0]] === searchValue[1];
-          }, true);
+          return searchEntries.every((item) => {
+            let [ key, value ] = item;
+            return account[key] === value;
+          });
         });
       });
     });


### PR DESCRIPTION
This allows to filter and find contributors by the account entries.

For example:

```js

Contributor.filterByAccount({site: 'github.com'}); // returns an array of all contributors with github account
Contributor.filterByAccount({site: 'github.com', username: 'bumi'}); // returns an array with bumi as single entry

Contributor.findByAccount({site: 'github.com', username: 'bumi'}); // returns the matching contributor 
Contributor.findByAccount({site: 'github.com'}); // returns the matching contributor - the first with a github.com account entry
```