### PR TITLE
Don't run `npm install` on bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "repl": "truffle exec scripts/repl.js",
     "seeds": "truffle exec scripts/seeds.js",
     "compile-contracts": "aragon contracts compile --all",
-    "bootstrap": "./scripts/every-app.sh \"npm install \" && npm run reset:hard && npm run seeds",
+    "bootstrap": "npm run reset:hard && npm run seeds",
     "reset": "npm run deploy:kit && npm run deploy:dao",
     "reset:hard": "npm run deploy:apps && npm run reset",
     "deploy:kit": "npm run compile-contracts && aragon contracts exec scripts/deploy-kit.js",


### PR DESCRIPTION
When one wants to install, they can install. When one wants to bootstrap, they should be able to only bootstrap.