### PR TITLE
Store kredits tokens as wei with 18 decimals

### DIFF
--- a/apps/token/contracts/Token.sol
+++ b/apps/token/contracts/Token.sol
@@ -14,11 +14,15 @@ contract Token is ERC20Token, AragonApp {
 
   function initialize(bytes32[4] _appIds) public onlyInit {
     appIds = _appIds;
+    name = 'Kredits';
+    symbol = 'K';
+    decimals = 18;
     initialized();
   }
 
   function mintFor(address contributorAccount, uint256 amount, uint32 contributionId) public isInitialized auth(MINT_TOKEN_ROLE) {
-    _mint(contributorAccount, amount);
+    uint256 amountInWei = amount.mul(1 ether);
+    _mint(contributorAccount, amountInWei);
     emit LogMint(contributorAccount, amount, contributionId);
   }
 

--- a/apps/token/contracts/Token.sol
+++ b/apps/token/contracts/Token.sol
@@ -15,7 +15,7 @@ contract Token is ERC20Token, AragonApp {
   function initialize(bytes32[4] _appIds) public onlyInit {
     appIds = _appIds;
     name = 'Kredits';
-    symbol = 'K';
+    symbol = '₭S';
     decimals = 18;
     initialized();
   }

--- a/scripts/list-contributors.js
+++ b/scripts/list-contributors.js
@@ -1,5 +1,6 @@
 const promptly = require('promptly');
 const Table = require('cli-table');
+const ethers = require('ethers');
 
 const initKredits = require('./helpers/init_kredits.js');
 
@@ -27,7 +28,7 @@ module.exports = async function(callback) {
       c.account,
       c.isCore,
       `${c.name}`,
-      c.balance.toString()
+      ethers.utils.formatEther(c.balance)
     ])
   })
   console.log(table.toString())


### PR DESCRIPTION
This stores the tokens with 18 decimals as most other tokens and as
assumed by a potential future token standard EIP 777.

This changes the return value of the balance of contributors which would need to be converted to "ether" in the client.