### PR TITLE
Deprecate old add* methods

### DIFF
--- a/lib/contracts/contribution.js
+++ b/lib/contracts/contribution.js
@@ -59,7 +59,7 @@ class Contribution extends Record {
   }
 
   addContribution () {
-    deprecate('The method: `addContribution` is deprecated use `add` instead');
+    deprecate('The function `addContribution()` is deprecated and will be removed in the next major version. Use `add()` instead');
     return this.add(...arguments);
   }
 }

--- a/lib/contracts/contribution.js
+++ b/lib/contracts/contribution.js
@@ -60,7 +60,7 @@ class Contribution extends Record {
 
   addContribution () {
     deprecate('The method: `addContribution` is deprecated use `add` instead');
-    this.add(...arguments);
+    return this.add(...arguments);
   }
 }
 

--- a/lib/contracts/contribution.js
+++ b/lib/contracts/contribution.js
@@ -1,5 +1,6 @@
 const Record = require('./record');
 const ContributionSerializer = require('../serializers/contribution');
+const deprecate = require('./utils/deprecate');
 
 class Contribution extends Record {
   get count () {
@@ -34,7 +35,7 @@ class Contribution extends Record {
       });
   }
 
-  async addContribution (contributionAttr, callOptions = {}) {
+  async add (contributionAttr, callOptions = {}) {
     const contribution = new ContributionSerializer(contributionAttr);
 
     try { await contribution.validate(); }
@@ -55,6 +56,11 @@ class Contribution extends Record {
 
         return this.functions.add(...contribution, callOptions);
       });
+  }
+
+  addContribution () {
+    deprecate('The method: `addContribution` is deprecated use `add` instead');
+    this.add(...arguments);
   }
 }
 

--- a/lib/contracts/proposal.js
+++ b/lib/contracts/proposal.js
@@ -1,5 +1,6 @@
 const Record = require('./record');
 const ContributionSerializer = require('../serializers/contribution');
+const deprecate = require('./utils/deprecate');
 
 class Proposal extends Record {
   get count () {
@@ -13,7 +14,7 @@ class Proposal extends Record {
       });
   }
 
-  async addProposal (proposalAttr, callOptions = {}) {
+  async add (proposalAttr, callOptions = {}) {
     const contribution = new ContributionSerializer(proposalAttr);
 
     try { await contribution.validate(); }
@@ -34,6 +35,11 @@ class Proposal extends Record {
 
         return this.functions.addProposal(...proposal, callOptions);
       });
+  }
+
+  addProposal () {
+    deprecate('The method: `addProposal` is deprecated use `add` instead');
+    this.add(...arguments);
   }
 }
 

--- a/lib/contracts/proposal.js
+++ b/lib/contracts/proposal.js
@@ -39,7 +39,7 @@ class Proposal extends Record {
 
   addProposal () {
     deprecate('The method: `addProposal` is deprecated use `add` instead');
-    this.add(...arguments);
+    return this.add(...arguments);
   }
 }
 

--- a/lib/contracts/proposal.js
+++ b/lib/contracts/proposal.js
@@ -38,7 +38,7 @@ class Proposal extends Record {
   }
 
   addProposal () {
-    deprecate('The method: `addProposal` is deprecated use `add` instead');
+    deprecate('The function `addProposal()` is deprecated and will be removed in the next major version. Use `add()` instead');
     return this.add(...arguments);
   }
 }


### PR DESCRIPTION
As we no longer have the operator contract we can deprecate the redundant add methods.
Now it should be clear what is added from the contract name.

I think it's good to deprecate early. The deprecate function could be extended so we can add a version number for the removal.