### PR TITLE
Fix apps lookup

### DIFF
--- a/scripts/deploy-kit.js
+++ b/scripts/deploy-kit.js
@@ -35,7 +35,7 @@ module.exports = async function(callback) {
   }
   console.log(`Using DAOFactory at: ${daoFactory.address}`)
 
-  const apps = fs.readdirSync('./apps')
+  const apps = fs.readdirSync('./apps', {withFileTypes: true}).filter(e => e.isDirectory()).map(e => e.name)
   console.log(`Found apps: [${apps}].${apm}`)
   let appIds = {}
   apps.sort().forEach((app) => {

--- a/scripts/deploy-kit.js
+++ b/scripts/deploy-kit.js
@@ -35,7 +35,9 @@ module.exports = async function(callback) {
   }
   console.log(`Using DAOFactory at: ${daoFactory.address}`)
 
-  const apps = fs.readdirSync('./apps', {withFileTypes: true}).filter(e => e.isDirectory()).map(e => e.name)
+  const apps = fs.readdirSync('./apps', { withFileTypes: true })
+                 .filter(e => e.isDirectory())
+                 .map(e => e.name);
   console.log(`Found apps: [${apps}].${apm}`)
   let appIds = {}
   apps.sort().forEach((app) => {


### PR DESCRIPTION
We use the directories in ./apps to load available app names.
For this we need to make sure that we only use directories.


Some recent change broke this by adding a file in the apps directory.
So without this fix no DAO can be deployed.