### PR TITLE
Fix canPerform method

### DIFF
--- a/apps/contributor/contracts/Contributor.sol
+++ b/apps/contributor/contracts/Contributor.sol
@@ -144,7 +144,7 @@ contract Contributor is AragonApp {
     exists = c.exists;
   }
 
-  function canPerform(address _who, address _where, bytes32 _what/*, uint256[] memory _how*/) public returns (bool) {
+  function canPerform(address _who, address _where, bytes32 _what, uint256[] memory _how) public returns (bool) {
     address sender = _who;
     if (sender == address(-1)) {
       sender = tx.origin;


### PR DESCRIPTION
Even if the variable is not used and the linter might complain we have
to have that parameter in the signature. otherwise the method is not
found and can not be called.