### PR TITLE
Fix page number calculation for zero records

### DIFF
--- a/lib/utils/pagination.js
+++ b/lib/utils/pagination.js
@@ -4,8 +4,8 @@ function pageNumber (number, size, recordCount) {
   number = parseInt(number) || 1;
 
   // Ensure page number is in range
-  number = number < 1 ? 1 : number;
   number = number > numberOfPages ? numberOfPages : number;
+  number = number < 1 ? 1 : number;
 
   return number;
 }


### PR DESCRIPTION
So far it returned 0 because of those in range checks which both
applied because numberOfPages is 0 if we have no record.