### PR TITLE
Allow setting any contributor accounts

### DIFF
--- a/lib/serializers/contributor.js
+++ b/lib/serializers/contributor.js
@@ -28,6 +28,7 @@ class Contributor {
       github_username,
       gitea_username,
       wiki_username,
+      accounts
     } = this;
 
     let data = {
@@ -35,7 +36,7 @@ class Contributor {
       '@type': 'Contributor',
       kind,
       name,
-      'accounts': [],
+      'accounts': (accounts || []),
     };
 
     if (url) {

--- a/lib/serializers/contributor.js
+++ b/lib/serializers/contributor.js
@@ -36,7 +36,7 @@ class Contributor {
       '@type': 'Contributor',
       kind,
       name,
-      'accounts': (accounts || []),
+      accounts: accounts || [],
     };
 
     if (url) {

--- a/lib/serializers/contributor.js
+++ b/lib/serializers/contributor.js
@@ -28,7 +28,7 @@ class Contributor {
       github_username,
       gitea_username,
       wiki_username,
-      accounts
+      accounts,
     } = this;
 
     let data = {


### PR DESCRIPTION
This allows to pass in an account object when creating or updating a
contribtor.

So far this was only possible by setting the `github_username` etc. attributes.