### PR TITLE
Add helper to initialize a new instance with provider

### DIFF
--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -66,6 +66,23 @@ class Kredits {
     return new Kredits(provider, signer, { ipfsConfig: ipfsConfig }).init();
   }
 
+  static for (connectionOptions, kreditsOptions) {
+    const { network, rpcUrl, wallet } = connectionOptions;
+    if (!rpcUrl && network === 'local') { rpcUrl = 'http://localhost:8545'; }
+    let ethProvider, signer;
+    if (rpcUrl || network === 'local') {
+      ethProvider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    } else {
+      ethProvider = new ethers.getDefaultProvider(network);
+    }
+    if (wallet) {
+      signer = wallet.connect(ethProvider);
+    } else if (ethProvider.getSigner) {
+      signer = ethProvider.getSigner();
+   }
+    return new Kredits(ethProvider, signer, kreditsOptions);
+  }
+
   get Kernel () {
     let k = this.contractFor('Kernel');
     // in case we want to use a special apm (e.g. development vs. production)

--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -70,7 +70,7 @@ class Kredits {
     let { network, rpcUrl, wallet } = connectionOptions;
     if (!rpcUrl && network === 'local') { rpcUrl = 'http://localhost:8545'; }
     let ethProvider, signer;
-    if (rpcUrl || network === 'local') {
+    if (rpcUrl) {
       ethProvider = new ethers.providers.JsonRpcProvider(rpcUrl);
     } else {
       ethProvider = new ethers.getDefaultProvider(network);

--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -67,7 +67,7 @@ class Kredits {
   }
 
   static for (connectionOptions, kreditsOptions) {
-    const { network, rpcUrl, wallet } = connectionOptions;
+    let { network, rpcUrl, wallet } = connectionOptions;
     if (!rpcUrl && network === 'local') { rpcUrl = 'http://localhost:8545'; }
     let ethProvider, signer;
     if (rpcUrl || network === 'local') {

--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -79,7 +79,7 @@ class Kredits {
       signer = wallet.connect(ethProvider);
     } else if (ethProvider.getSigner) {
       signer = ethProvider.getSigner();
-   }
+    }
     return new Kredits(ethProvider, signer, kreditsOptions);
   }
 


### PR DESCRIPTION
So far we always had to initialze a provider and signer and pass those
to the kredits constructor.
This helper makes it easier to initialize a default ethers provider and
a default signer.

Examples:

```js
Kredits.for({network: 'local'}).init();
Kredits.for({network: 'rinkeby'}, {apm: 'open.aragonpm.eth'}).init();
```