### PR TITLE
Expose available network IDs

### DIFF
--- a/lib/kredits.js
+++ b/lib/kredits.js
@@ -83,6 +83,10 @@ class Kredits {
     return new Kredits(ethProvider, signer, kreditsOptions);
   }
 
+  static availableNetworks () {
+    return Object.keys(DaoAddresses);
+  }
+
   get Kernel () {
     let k = this.contractFor('Kernel');
     // in case we want to use a special apm (e.g. development vs. production)


### PR DESCRIPTION
This exposes the network IDs on which kredits is deployed. Helpful to
check if the used network is supported.