### PR TITLE
Add support to use IPFS gateway to read ipfs data

### DIFF
--- a/lib/utils/ipfs.js
+++ b/lib/utils/ipfs.js
@@ -1,13 +1,14 @@
 const ipfsClient = require('ipfs-http-client');
 const multihashes = require('multihashes');
+const fetch = require('node-fetch');
 
 class IPFS {
   constructor (config) {
     if (!config) {
       config = { host: 'localhost', port: '5001', protocol: 'http' };
     }
-    this._ipfsAPI = ipfsClient(config);
     this._config = config;
+    this._ipfsAPI = ipfsClient(config);
   }
 
   catAndMerge (data, deserialize) {
@@ -38,7 +39,11 @@ class IPFS {
     if (hashData.hasOwnProperty('hashSize')) {
       ipfsHash = this.encodeHash(hashData);
     }
-    return this._ipfsAPI.cat(ipfsHash);
+    if (this._config['gatewayUrl']) {
+      return fetch(`${this._config['gatewayUrl']}/${ipfsHash}`).then(r => r.text());
+    } else {
+      return this._ipfsAPI.cat(ipfsHash);
+    }
   }
 
   pin (hashData) {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ethers": "^4.0.29",
     "ipfs-http-client": "^32.0.1",
     "kosmos-schemas": "^2.1.0",
+    "node-fetch": "^2.6.0",
     "tv4": "^1.3.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "ethers": "^4.0.29",
-    "ipfs-http-client": "^32.0.1",
+    "ipfs-http-client": "^30.1.3",
     "kosmos-schemas": "^2.1.0",
     "node-fetch": "^2.6.0",
     "tv4": "^1.3.0"


### PR DESCRIPTION
This makes caching of IPFS documents easier. Browsers should cache those
by default