### PR TITLE
Add support for zoom profiles

### DIFF
--- a/lib/serializers/contributor.js
+++ b/lib/serializers/contributor.js
@@ -27,8 +27,7 @@ class Contributor {
       github_uid,
       github_username,
       gitea_username,
-      wiki_username,
-      accounts,
+      wiki_username
     } = this;
 
     let data = {
@@ -36,7 +35,7 @@ class Contributor {
       '@type': 'Contributor',
       kind,
       name,
-      accounts: accounts || [],
+      accounts: [],
     };
 
     if (url) {
@@ -65,6 +64,13 @@ class Contributor {
         'site': 'wiki.kosmos.org',
         'username': wiki_username,
         'url': `https://wiki.kosmos.org/User:${wiki_username}`,
+      });
+    }
+
+    if (zoom_name) {
+      data.accounts.push({
+        'site': 'zoom.us',
+        'username': zoom_name
       });
     }
 
@@ -101,6 +107,7 @@ class Contributor {
     let github = accounts.find(a => a.site === 'github.com');
     let gitea  = accounts.find(a => a.site === 'gitea.kosmos.org');
     let wiki   = accounts.find(a => a.site === 'wiki.kosmos.org');
+    let zoom   = accounts.find(a => a.site === 'zoom.us');
 
     if (github) {
       (({ username: github_username, uid: github_uid} = github));
@@ -110,6 +117,9 @@ class Contributor {
     }
     if (wiki) {
       (({ username: wiki_username } = wiki));
+    }
+    if (zoom) {
+      (({ username: zoom_name } = zoom));
     }
 
     return {
@@ -121,6 +131,7 @@ class Contributor {
       github_username,
       gitea_username,
       wiki_username,
+      zoom_name,
       ipfsData: serialized,
     };
   }

--- a/lib/serializers/contributor.js
+++ b/lib/serializers/contributor.js
@@ -28,7 +28,7 @@ class Contributor {
       github_username,
       gitea_username,
       wiki_username,
-      zoom_name,
+      zoom_display_name,
     } = this;
 
     let data = {
@@ -68,10 +68,10 @@ class Contributor {
       });
     }
 
-    if (zoom_name) {
+    if (zoom_display_name) {
       data.accounts.push({
         'site': 'zoom.us',
-        'username': zoom_name,
+        'username': zoom_display_name,
       });
     }
 
@@ -104,7 +104,7 @@ class Contributor {
       accounts,
     } = JSON.parse(serialized.toString('utf8'));
 
-    let github_username, github_uid, gitea_username, wiki_username, zoom_name;
+    let github_username, github_uid, gitea_username, wiki_username, zoom_display_name;
     let github = accounts.find(a => a.site === 'github.com');
     let gitea  = accounts.find(a => a.site === 'gitea.kosmos.org');
     let wiki   = accounts.find(a => a.site === 'wiki.kosmos.org');
@@ -120,7 +120,7 @@ class Contributor {
       (({ username: wiki_username } = wiki));
     }
     if (zoom) {
-      (({ username: zoom_name } = zoom));
+      (({ username: zoom_display_name } = zoom));
     }
 
     return {
@@ -132,7 +132,7 @@ class Contributor {
       github_username,
       gitea_username,
       wiki_username,
-      zoom_name,
+      zoom_display_name,
       ipfsData: serialized,
     };
   }

--- a/lib/serializers/contributor.js
+++ b/lib/serializers/contributor.js
@@ -27,7 +27,8 @@ class Contributor {
       github_uid,
       github_username,
       gitea_username,
-      wiki_username
+      wiki_username,
+      zoom_name,
     } = this;
 
     let data = {
@@ -70,7 +71,7 @@ class Contributor {
     if (zoom_name) {
       data.accounts.push({
         'site': 'zoom.us',
-        'username': zoom_name
+        'username': zoom_name,
       });
     }
 
@@ -103,7 +104,7 @@ class Contributor {
       accounts,
     } = JSON.parse(serialized.toString('utf8'));
 
-    let github_username, github_uid, gitea_username, wiki_username;
+    let github_username, github_uid, gitea_username, wiki_username, zoom_name;
     let github = accounts.find(a => a.site === 'github.com');
     let gitea  = accounts.find(a => a.site === 'gitea.kosmos.org');
     let wiki   = accounts.find(a => a.site === 'wiki.kosmos.org');


### PR DESCRIPTION
This adds an accessor for the zoom_name to the contributor profile.
Doing this also removes general support for preserviing the contributor
accounts array as this was buggy and caused accounts to be added
multiple times.