### PR TITLE
Lock node.js to 12 on CI, add note for devs to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "lts/*"
+  - "12"
 
 sudo: false
 dist: xenial

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Aragon CLI and Truffle need to be installed on your sytem as well:
     npm install -g @aragon/cli
     npm install -g truffle
 
+_Note: `@aragon/cli` currently fails to install on node.js 14. Please use
+node.js 12 until the issue has been resolved upstream._
+
 ### Local development chain
 
 For local development it is recommended to use


### PR DESCRIPTION
Add note about having to use node.js 12 for now.