### PR TITLE
Fix confirmations being 1 block too late

### DIFF
--- a/apps/contribution/contracts/Contribution.sol
+++ b/apps/contribution/contracts/Contribution.sol
@@ -164,7 +164,7 @@ contract Contribution is AragonApp {
     if (contributionId < 10) {
       c.confirmedAtBlock = block.number;
     } else {
-      c.confirmedAtBlock = block.number + blocksToWait;
+      c.confirmedAtBlock = block.number + 1 + blocksToWait;
     }
 
     contributionsCount++;


### PR DESCRIPTION
block.number refers to the last mined block, so we need to add +1 to wait from the current block on (the one in which this function is executed).